### PR TITLE
TST: reproduce failure for timestamp issue

### DIFF
--- a/gateway_tests/process/test_enum_undefined_timestamp.py
+++ b/gateway_tests/process/test_enum_undefined_timestamp.py
@@ -72,8 +72,6 @@ def test_undefined_timestamp_subscription(subscription_mask):
             assert gateway_md["timestamp"] != 0, "2nd CA get timestamp is undefined!"
             assert ioc_md["value"] == gateway_md["value"]
 
-            time.sleep(0.1)
-
 
 @conftest.standard_test_environment_decorator
 def test_undefined_timestamp_get_only():
@@ -101,5 +99,3 @@ def test_undefined_timestamp_get_only():
         if ioc_md["status"] != dbr.AlarmStatus.UDF:
             assert gateway_md["status"] != dbr.AlarmStatus.UDF, "2nd CA get is undefined!"
         assert ioc_md["value"] == gateway_md["value"]
-
-        time.sleep(0.1)


### PR DESCRIPTION
At last, this reproduces the timestamp issue in the test suite.

This uses low-level pyepics `epics.ca` tooling to avoid `epics.PV` and its implicit subscription mechanism and anything else it might do.

Here's the results:

R2.1.2.0-1.3.0
```
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_subscription[DBE_VALUE] PASSED                                                      [ 12%]
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_subscription[DBE_LOG] PASSED                                                        [ 25%]
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_subscription[DBE_ALARM] PASSED                                                      [ 37%]
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_subscription[DBE_PROPERTY] PASSED                                                   [ 50%]
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_subscription[DBE_VALUE|DBE_PROPERTY] PASSED                                         [ 62%]
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_subscription[DBE_VALUE|DBE_LOG] PASSED                                              [ 75%]
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_subscription[DBE_VALUE|DBE_ALARM] PASSED                                            [ 87%]
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_get_only FAILED                                                                     [100%]

================================================================================= FAILURES =================================================================================
____________________________________________________________________ test_undefined_timestamp_get_only _____________________________________________________________________
@conftest.standard_test_environment_decorator
    def test_undefined_timestamp_get_only():
        """
        caget on an mbbi - without subscription configured.

        All timestamps should be defined.
        """
        for iteration in range(1, 5):
            logger.info("Iteration %d", iteration)
            ioc_md, gateway_md = conftest.pyepics_caget_pair("HUGO:ENUM", form="time")
            logger.info(
                "IOC timestamp: %s (%s)",
                ioc_md["timestamp"], timestamp_to_string(ioc_md["timestamp"])
            )
            logger.info(
                "Gateway timestamp: %s (%s)",
                gateway_md["timestamp"], timestamp_to_string(gateway_md["timestamp"])
            )

            assert ioc_md["timestamp"] != UNDEFINED_TIMESTAMP, "IOC timestamp undefined"
>           assert gateway_md["timestamp"] != UNDEFINED_TIMESTAMP, "Gateway timestamp undefined"
E           AssertionError: Gateway timestamp undefined
E           assert 631152000.0 != 631152000.0

gateway_tests/process/test_enum_undefined_timestamp.py:98: AssertionError
---------------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------------
INFO     gateway_tests.conftest:conftest.py:111 Running: /cds/group/pcds/epics/extensions/gateway/R2.1.2.0-1.3.0/bin/rhel7-x86_64/gateway -sip localhost -sport 12783 -cip localhost -cport 12782 -access /cds/home/k/klauer/Repos/pcds-gateway-tests/gateway_tests/process/default_access.txt -pvlist /cds/home/k/klauer/Repos/pcds-gateway-tests/gateway_tests/process/pvlist_bre.txt -archive -prefix gwtest (verbose=False)
INFO     gateway_tests.conftest:conftest.py:111 Running: /reg/g/pcds/epics/base/R7.0.2-2.0/bin/rhel7-x86_64/softIoc -d /cds/home/k/klauer/Repos/pcds-gateway-tests/gateway_tests/process/test.db (verbose=False)
INFO     gateway_tests.process.test_enum_undefined_timestamp:test_enum_undefined_timestamp.py:86 Iteration 1
INFO     gateway_tests.process.test_enum_undefined_timestamp:test_enum_undefined_timestamp.py:88 IOC timestamp: 1630352715.799342 (Mon Aug 30 12:45:15 2021)
INFO     gateway_tests.process.test_enum_undefined_timestamp:test_enum_undefined_timestamp.py:92 Gateway timestamp: 1630352715.799342 (Mon Aug 30 12:45:15 2021)
INFO     gateway_tests.process.test_enum_undefined_timestamp:test_enum_undefined_timestamp.py:86 Iteration 2
INFO     gateway_tests.process.test_enum_undefined_timestamp:test_enum_undefined_timestamp.py:88 IOC timestamp: 1630352715.799342 (Mon Aug 30 12:45:15 2021)
INFO     gateway_tests.process.test_enum_undefined_timestamp:test_enum_undefined_timestamp.py:92 Gateway timestamp: 631152000.0 (<undefined>)
========================================================================= short test summary info ==========================================================================
FAILED gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_get_only
```

R2.1.2.0-1.4.0
```
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_subscription[DBE_VALUE] PASSED
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_subscription[DBE_LOG] PASSED
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_subscription[DBE_ALARM] PASSED
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_subscription[DBE_PROPERTY] PASSED
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_subscription[DBE_VALUE|DBE_PROPERTY] PASSED
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_subscription[DBE_VALUE|DBE_LOG] PASSED
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_subscription[DBE_VALUE|DBE_ALARM] PASSED
gateway_tests/process/test_enum_undefined_timestamp.py::test_undefined_timestamp_get_only PASSED
```