### PR TITLE
FIX: ophyd import breaking process tests; hotfix softIoc location with differing host arch string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ PYTEST_OPTIONS ?=
 DEVICE_CONFIG_DB ?= /cds/group/pcds/pyps/apps/hutch-python/device_config/db.json
 
 
+process-tests:
+	@echo "* Running gateway process tests with options: $(PYTEST_OPTIONS)"
+	GATEWAY_ROOT=$(GATEWAY_ROOT) \
+			pytest -v --forked gateway_tests/process \
+					$(PYTEST_OPTIONS)
+
 gateway_tests/happi_info.json: $(DEVICE_CONFIG_DB)
 	@echo "Updating happi_info.json based on device_config database..."
 	@python -m whatrecord.plugins.happi > $@
@@ -17,9 +23,10 @@ missing-pvs-report: gateway_tests/happi_info.json
 
 
 tests: gateway_tests/happi_info.json
+	@echo "* Running all tests with options: $(PYTEST_OPTIONS)"
 	GATEWAY_ROOT=$(GATEWAY_ROOT) \
 			pytest -v --forked gateway_tests \
 					$(PYTEST_OPTIONS)
 
 
-.PHONY: missing-pvs-report tests
+.PHONY: missing-pvs-report tests process-tests

--- a/README.md
+++ b/README.md
@@ -83,3 +83,5 @@ Notes on tests
 
 * ``test_undefined_timestamp`` does not sufficiently trigger the issue it
   intends to.  It needs revisiting.
+
+https://confluence.slac.stanford.edu/display/PCDS/Gateway+testing+by+way+of+pcds-gateway-tests

--- a/README.md
+++ b/README.md
@@ -10,13 +10,25 @@ tests/
 For starters, a pytest conversion of [ca-gateway
 tests](https://github.com/slac-epics/ca-gateway/tree/R2.1.2.0-1.branch/testTop/pyTestsApp)
 
+These tests are called the "process" tests in this repository and are located
+in ``gateway_tests/process/``.  Tests which are tied to PCDS's production
+configuration are referred to as "prod config" tests and are located in
+``gateway_tests/prod_config``.
 
 Test Requirements
 -----------------
 
+* Python 3.8+
 * pytest
 * pytest-xdist (*)
+* [pyepics](https://github.com/pyepics/pyepics)
+* [caproto](https://github.com/caproto/caproto)
 
+For production configuration tests, the following dependencies are also
+required:
+
+* [apischema](https://github.com/wyfo/apischema/)
+* [whatrecord](https://github.com/pcdshub/whatrecord/)
 
 (*) This is important to run each test in a separate process.  pyepics does
 not handle ``epics.PV`` and context clearing well, so you may get segfaults
@@ -26,6 +38,45 @@ Individual fixtures that use ``epics`` to determine support of gateway features
 should be done carefully by performing their task in a separate process to
 avoid interfering with the test suite (see ``conftest.prop_supported`` for an
 example).
+
+Test environment
+----------------
+
+Tests can be run from the latest PCDS Python environment.  To use it, source
+the following script with bash:
+
+```bash
+$ source /cds/group/pcds/pyps/conda/pcds_conda
+```
+
+For more information, see
+https://confluence.slac.stanford.edu/display/PCDS/PCDS+Conda+Python+Environments
+
+Process tests
+-------------
+
+To run just the process tests, ensure the Python environment contains the
+minimum requirements.
+
+This should work as-is:
+
+```bash
+$ make process-tests PYTEST_OPTIONS=""
+```
+
+Or customize the gateway process/host arch you are testing with environment
+settings and ``PYTEST_OPTIONS``:
+
+```bash
+$ export EPICS_HOST_ARCH=rhel7-x86_64
+$ export GATEWAY_ROOT=/cds/group/pcds/epics/extensions/gateway/R2.1.2.0-1.2.0/
+$ make process-tests PYTEST_OPTIONS="-k simple"
+* Running gateway process tests with options: -k simple
+GATEWAY_ROOT=/cds/group/pcds/epics/extensions/gateway/R2.1.2.0-1.2.0/ \
+                pytest -v --forked gateway_tests/process \
+                                -k simple
+```
+
 
 Notes on tests
 --------------

--- a/README.md
+++ b/README.md
@@ -86,6 +86,57 @@ for clearing and creating new CA contexts and not something we really have
 control over.
 
 
+Included process tests
+----------------------
+
+* ``CS studio``: VALUE|ALARM with time structure, PROPERTY with control
+  structure
+* ``DBE_ALARM``: alarm severity transitions are accurate
+* ``DBE_LOG``: archive deadband settings respected
+* ``DBE_PROPERTY``: HIHI/LOLO/HI/LO changes result in monitor events
+* ``DBE_VALUE``: simply ensure monitors are consistent
+* ``enum_property_cache``: PV property cache for enum data (2 xfails; did not
+  dig into details); stale enum data check (passes)
+* ``enum_undefined_timestamp``: SLAC-reported timestamp issue of undefined
+  timestamps for enum PVs.
+* ``property_cache``: EGU, limit, etc. updated and then verified valid using a
+  CTRL request
+* ``structures``: CTRL metadata identical in monitor events
+* ``waveform_with_max_ca_array_bytes``: gateway segfault check when IOC
+  ``EPICS_CA_MAX_ARRAY_BYTES`` is set too low
+
+Additional SLAC-created tests:
+
+* ``enum_undefined_timestamp``: SLAC-reported timestamp issue of undefined
+  timestamps for enum PVs now easily reproduces the issue. Additional test for
+  this lingering issue.
+* ``subscriptions``: verify subscription metadata for the matrix of settings
+  below, upon connection and after performing a number of caputs
+  * ``DBE_{VALUE,LOG,ALARM,PROPERTY}`` (and a mix thereof) CTRL and TIME types
+  * Records used in the test suite
+* ``permissions``: validate that access security groups work as expected
+  * Allow by host/user (*), deny by specific IP (DENY FROM), blanket deny
+* ``logging``: verify caPutLog behavior
+  * For provided records, perform a caput and verify the log output is valid.
+    Similarly, check the TCP output
+
+Included production configuration tests
+---------------------------------------
+
+New production tests
+
+* Base a new test suite on our production PCDS configuration
+* Gather data from whatrecord
+  * Python-parsed gateway configuration (.pvlist) and access security (.acf)
+    happi database device mapping to PVs
+* Add in pertinent test suite information
+  * Map PV to IOC -> IOC to host -> host to subnet
+  * Per gateway-host interface information
+* With all of the above, run on a gateway host to check
+   * Access rights are correct according to the configuration
+   * PV metadata is accurate from the gateway versus the IOC
+* Produce human-readable results of any discrepancies
+
 Notes on tests
 --------------
 

--- a/README.md
+++ b/README.md
@@ -77,11 +77,29 @@ GATEWAY_ROOT=/cds/group/pcds/epics/extensions/gateway/R2.1.2.0-1.2.0/ \
                                 -k simple
 ```
 
+You can also just use ``pytest`` directly, as indicated by the ``make`` output
+above.  Just be sure you use ``--forked`` mode, otherwise the tools we have
+built in to reconfigure EPICS CA environment variables specifically for testing
+may not work correctly.
 
 Notes on tests
 --------------
 
 * ``test_undefined_timestamp`` does not sufficiently trigger the issue it
   intends to.  It needs revisiting.
+* For the process tests, each test spawns its own gateway instance and its own
+  IOC instance.
+* The default test database has a prefix of ``ioc:``, but tests may communicate
+  to the same PV through the gateway instance by swapping that prefix for
+  ``gateway:``.  This is a fundamental pattern reused in many tests here.
+  The gateway configurations (``gateway_tests/process/pvlist*.txt``) include
+  this alias rule which does this: ``gateway:\(.*\)  ALIAS ioc:\1``.
+* PCRE and BRE pvlist configurations for the gateway are available and may be
+  configured by way of the ``GATEWAY_PVLIST`` environment variable.
+* The gateway process and the IOC process work on different
+  ``EPICS_CA_SERVER_PORT`` settings, making communicating with one or the other
+  a matter of environment variable configuration.
+* Though we use pytest-xdist, the port configuration here does not allow for
+  parallel testing, so do not use ``-n`` values of ``>= 2``.
 
 https://confluence.slac.stanford.edu/display/PCDS/Gateway+testing+by+way+of+pcds-gateway-tests

--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ configuration are referred to as "prod config" tests and are located in
 Test Requirements
 -----------------
 
-* Python 3.8+
-* pytest
-* pytest-xdist (*)
-* [pyepics](https://github.com/pyepics/pyepics)
+* Python 3.9+ (type annotations will fail on earlier versions)
 * [caproto](https://github.com/caproto/caproto)
+* [numpy](https://numpy.org/)
+* [pyepics](https://github.com/pyepics/pyepics)
+* [pytest-xdist](https://github.com/pytest-dev/pytest-xdist) (*)
+* [pytest](https://github.com/pytest-dev/pytest)
 
 For production configuration tests, the following dependencies are also
 required:
@@ -78,9 +79,12 @@ GATEWAY_ROOT=/cds/group/pcds/epics/extensions/gateway/R2.1.2.0-1.2.0/ \
 ```
 
 You can also just use ``pytest`` directly, as indicated by the ``make`` output
-above.  Just be sure you use ``--forked`` mode, otherwise the tools we have
-built in to reconfigure EPICS CA environment variables specifically for testing
-may not work correctly.
+above.  Just be sure you use ``--forked`` mode when running more than one
+test.  The test suite will fail all subsequent tests after the first one
+otherwise.  This is largely due to working around pyepics's flimsy support
+for clearing and creating new CA contexts and not something we really have
+control over.
+
 
 Notes on tests
 --------------

--- a/gateway_tests/conftest.py
+++ b/gateway_tests/conftest.py
@@ -89,7 +89,7 @@ except KeyError:
 
 if not os.path.exists(gateway_executable):
     raise RuntimeError(
-        f"Gateway executable {gateway_executable} does not exist; set GW_SITE_TOP."
+        f"Gateway executable {gateway_executable} does not exist; set GATEWAY_ROOT."
     )
 
 if "IOC_EPICS_BASE" in os.environ:
@@ -99,10 +99,12 @@ if "IOC_EPICS_BASE" in os.environ:
 elif "EPICS_BASE" in os.environ:
     ioc_executable = os.path.join(os.environ["EPICS_BASE"], "bin", hostArch, "softIoc")
 else:
-    ioc_executable = shutil.which("softIoc")
+    ioc_executable = None
 
 if not ioc_executable or not os.path.exists(ioc_executable):
-    raise RuntimeError(f"softIoc path {ioc_executable} does not exist")
+    ioc_executable = shutil.which("softIoc")
+    if not ioc_executable:
+        raise RuntimeError(f"softIoc path {ioc_executable} does not exist")
 
 
 @contextlib.contextmanager

--- a/gateway_tests/conftest.py
+++ b/gateway_tests/conftest.py
@@ -34,7 +34,13 @@ from typing import Any, ContextManager, Generator, Iterable, Optional, Protocol
 import epics
 import pytest
 
-from .config import PCDSConfiguration
+try:
+    from .config import PCDSConfiguration
+except ImportError:
+    # PCDSConfiguration should be optional, but prod_tests will not function
+    # without it.
+    PCDSConfiguration = None
+
 from .constants import MODULE_PATH, PCDS_ACCESS
 from .util import PVInfo
 

--- a/gateway_tests/conftest.py
+++ b/gateway_tests/conftest.py
@@ -36,13 +36,13 @@ import pytest
 
 import epics
 
-from .constants import MODULE_PATH, PCDS_ACCESS
-from .util import PVInfo
-
 # Don't let ophyd's control layer get in the way of pyepics's initialization.
 # If left to the default, pyepics will initialize libca with the current
 # environment's configuration.
 os.environ["OPHYD_CONTROL_LAYER"] = "dummy"
+
+from .constants import MODULE_PATH, PCDS_ACCESS  # noqa: E402  # isort: skip
+from .util import PVInfo  # noqa: E402 # isort: skip
 
 try:
     from .config import PCDSConfiguration
@@ -129,7 +129,9 @@ def run_process(
     startup_time: float = 0.5,
     wait_for: Optional[bytes] = None,
 ):
-    """Run ``cmd`` and yield a subprocess.Popen instance."""
+    """
+    Run ``cmd`` and yield a subprocess.Popen instance.
+    """
     verbose = True
     logger.info("Running: %s (verbose=%s)", " ".join(cmd), verbose)
 
@@ -142,6 +144,7 @@ def run_process(
     )
 
     stdout = None
+    event = threading.Event()
 
     def read_stdout():
         """Read standard output in a background thread."""
@@ -178,11 +181,9 @@ def run_process(
                     textwrap.indent(str(stdout), "    "),
                 )
 
-    event = threading.Event()
     threading.Thread(daemon=True, target=read_stdout).start()
 
-    # Arbitrary startup time
-    # time.sleep(startup_time)
+    # Wait for the "ready" message event, up to ``startup_time`` seconds
     event.wait(startup_time)
     try:
         yield proc

--- a/gateway_tests/conftest.py
+++ b/gateway_tests/conftest.py
@@ -26,13 +26,23 @@ import shutil
 import subprocess
 import tempfile
 import textwrap
+import threading
 import time
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
 from typing import Any, ContextManager, Generator, Iterable, Optional, Protocol
 
-import epics
 import pytest
+
+import epics
+
+from .constants import MODULE_PATH, PCDS_ACCESS
+from .util import PVInfo
+
+# Don't let ophyd's control layer get in the way of pyepics's initialization.
+# If left to the default, pyepics will initialize libca with the current
+# environment's configuration.
+os.environ["OPHYD_CONTROL_LAYER"] = "dummy"
 
 try:
     from .config import PCDSConfiguration
@@ -40,9 +50,6 @@ except ImportError:
     # PCDSConfiguration should be optional, but prod_tests will not function
     # without it.
     PCDSConfiguration = None
-
-from .constants import MODULE_PATH, PCDS_ACCESS
-from .util import PVInfo
 
 logger = logging.getLogger(__name__)
 
@@ -53,8 +60,8 @@ if "PYEPICS_LIBCA" not in os.environ and os.path.exists(libca_so):
     os.environ["PYEPICS_LIBCA"] = libca_so
 
 # CA ports to use
-default_ioc_port = 12782
-default_gw_port = 12783
+default_ioc_port = 62782
+default_gw_port = 62783
 default_access = os.environ.get(
     "GATEWAY_ACCESS", str(MODULE_PATH / "process" / "default_access.txt")
 )
@@ -117,33 +124,77 @@ if not ioc_executable or not os.path.exists(ioc_executable):
 def run_process(
     cmd: list[str],
     env: dict[str, str],
-    verbose: bool = False,
+    verbose: bool = True,
     interactive: bool = False,
     startup_time: float = 0.5,
+    wait_for: Optional[bytes] = None,
 ):
     """Run ``cmd`` and yield a subprocess.Popen instance."""
+    verbose = True
     logger.info("Running: %s (verbose=%s)", " ".join(cmd), verbose)
 
-    with open(os.devnull, "wb") as dev_null:
-        proc = subprocess.Popen(
-            cmd,
-            env=env,
-            stdin=subprocess.PIPE,
-            stdout=dev_null if not verbose else None,
-            stderr=subprocess.STDOUT,
-        )
-        # Arbitrary startup time
-        time.sleep(startup_time)
-        try:
-            yield proc
-        finally:
-            if interactive:
-                logger.debug("Exiting interactive process %s", cmd[0])
-                proc.stdin.close()
-            else:
-                logger.debug("Terminating non-interactive process %s", cmd[0])
-                proc.terminate()
-            proc.wait()
+    proc = subprocess.Popen(
+        cmd,
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    stdout = None
+
+    def read_stdout():
+        """Read standard output in a background thread."""
+        nonlocal stdout
+        lines = []
+        t0 = time.monotonic()
+        while True:
+            line = proc.stdout.readline()
+            if not line:
+                break
+            if wait_for is not None and wait_for in line:
+                # Set the starting event if we see what we're waiting for
+                # to indicate the process is ready.
+                event.set()
+
+        stdout = b"".join(lines)
+        if verbose:
+            logger.warning(
+                "Read %d bytes from %s in %.1f sec",
+                len(stdout),
+                cmd[0],
+                time.monotonic() - t0,
+            )
+            if stdout:
+                try:
+                    stdout = stdout.decode("latin-1")
+                except Exception:
+                    stdout = str(stdout)
+
+                logger.warning(
+                    "Standard output for %s:\n"
+                    "    %s\n\n",
+                    cmd[0],
+                    textwrap.indent(str(stdout), "    "),
+                )
+
+    event = threading.Event()
+    threading.Thread(daemon=True, target=read_stdout).start()
+
+    # Arbitrary startup time
+    # time.sleep(startup_time)
+    event.wait(startup_time)
+    try:
+        yield proc
+    finally:
+        if interactive:
+            logger.debug("Exiting interactive process %s", cmd[0])
+            proc.stdin.close()
+        else:
+            logger.debug("Terminating non-interactive process %s", cmd[0])
+            proc.terminate()
+        proc.wait()
+        logger.info("Process %s exited", cmd[0])
 
 
 @contextlib.contextmanager
@@ -193,7 +244,9 @@ def run_ioc(
 
     cmd.extend(arglist)
 
-    with run_process(cmd, env, verbose=verbose, interactive=True) as proc:
+    with run_process(
+        cmd, env, verbose=verbose, interactive=True, wait_for=b"epics>"
+    ) as proc:
         yield proc
 
 
@@ -249,7 +302,9 @@ def run_gateway(
     if verbose:
         cmd.extend(["-debug", str(gateway_debug_level)])
 
-    with run_process(cmd, os.environ, verbose=verbose, interactive=False) as proc:
+    with run_process(
+        cmd, os.environ, verbose=verbose, interactive=False, wait_for=b"Running as user"
+    ) as proc:
         yield proc
 
 
@@ -267,20 +322,31 @@ def local_channel_access(
         provided, defaults to ``[default_ioc_port, default_gw_port]``.
     """
     if not len(ports):
-        ports = [default_ioc_port, default_gw_port]
+        ports = (default_ioc_port, default_gw_port)
 
     address_list = " ".join(f"localhost:{port}" for port in ports)
+    if epics.ca.libca is not None:  # epics.ca.libca is not epics.ca._LIBCA_FINALIZED
+        pytest.fail(
+            msg=(
+                "epics.ca.libca already initialized: "
+                "Some library initialized pyepics before pcds-gateway-tests "
+                "could configure the environment, or tests were run without "
+                "using pytest-fork and --forked. "
+                "Because the tests will fail - or worse, the process will "
+                "segfault - we are bailing early."
+            )
+        )
+
     with context_set_env("EPICS_CA_AUTO_ADDR_LIST", "NO"):
         with context_set_env("EPICS_CA_ADDR_LIST", address_list):
             epics.ca.initialize_libca()
             try:
                 yield
             finally:
-                # This may lead to instability - probably should only run one test per
-                # process
+                # This may lead to instability - probably should only run one
+                # test per process
                 epics.ca.clear_cache()
                 epics.ca.finalize_libca()
-                time.sleep(0.2)
 
 
 @contextlib.contextmanager

--- a/gateway_tests/process/test_permissions.py
+++ b/gateway_tests/process/test_permissions.py
@@ -22,6 +22,9 @@ logger = logging.getLogger(__name__)
 
 # Keep the header with regex rules separate; \\ is a pain to deal with in
 # strings.
+#
+# NOTE: this pvlist is done in BRE regex format and not PCRE and assumes
+# the gateway was built with it.
 pvlist_header = r"""
 EVALUATION ORDER ALLOW, DENY
 gateway:\(.*\)  ALIAS ioc:\1


### PR DESCRIPTION
## Changes and notes

* Ophyd import (and implicit libca initialization) was messing with `libca` environment settings
    * Forced `ophyd_control_layer` env var to avoid the above
* Added notes about the tests
* Added notes about test requirements and environment settings
* Reworked subprocess output grabbing stuff after scratching my head as to why nothing was working; verbose mode now dumps stderr/stdout to the logger at the end
* Made some dependencies optional (whatrecord / apischema) if the process tests are the ones to be run

## Unexpected failures
Four tests are failing unexpectedly. At least to my recollection, these should be passing:
```
FAILED gateway_tests/process/test_permissions.py::test_permissions_by_host_aliased[test-minimal]
FAILED gateway_tests/process/test_permissions.py::test_permissions_by_host_aliased[test-full]
FAILED gateway_tests/process/test_permissions.py::test_permissions_by_user_direct[test-minimal]
FAILED gateway_tests/process/test_permissions.py::test_permissions_by_user_direct[test-full]
```

Permissions appear to be coming back wrong, e.g.,
```
E                   AssertionError: AccessCheck(hostname='mfx-control', pvname='ioc:HUGO:ENUM', access='WRITE|READ', username=None)
E                   assert 'WRITE|READ' == 'READ'
E                     - READ
E                     + WRITE|READ
```

## Expected failures
Some caPutLog tests are failing, but to my recollection, they were failing before. I may have neglected to document those failures properly.